### PR TITLE
chore: bump to 0.18.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,8 @@ jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -38,15 +40,15 @@ jobs:
           TAG_OR_BRANCH: ${{ steps.refortag.outputs.value }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build jmx-exporter
         uses: docker/build-push-action@v2
         with:
-          tags: ghcr.io/banzaicloud/jmx-javaagent:${{ steps.imagetag.outputs.value }}
+          tags: ghcr.io/mesosphere/jmx-javaagent:${{ steps.imagetag.outputs.value }}
           file: Dockerfile
           platforms: ${{ env.PLATFORMS }}
           push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           tags: ghcr.io/mesosphere/jmx-javaagent:${{ steps.imagetag.outputs.value }}
           file: Dockerfile
-          platforms: ${{ env.PLATFORMS }}
+          platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM maven:3.8.4-eclipse-temurin-11 as build
-ARG VERSION=0.16.1
+ARG VERSION=0.18.0
 WORKDIR /
 USER root
 RUN \
@@ -18,5 +18,6 @@ RUN \
   && mvn clean package
 
 FROM busybox:latest
-COPY --from=build /jmx_exporter/jmx_prometheus_javaagent/target/jmx_prometheus_javaagent-*.jar /opt/jmx_exporter/
+ARG VERSION=0.18.0
+COPY --from=build /jmx_exporter/jmx_prometheus_javaagent/target/jmx_prometheus_javaagent-${VERSION}.jar /opt/jmx_exporter/
 RUN ln -s /opt/jmx_exporter/jmx_prometheus_javaagent-*.jar /jmx_prometheus_javaagent.jar


### PR DESCRIPTION
Bumping jmx exporter to 0.18.0 with fixed vulnerabilities.